### PR TITLE
Remove unnused authorization-django middleware

### DIFF
--- a/web/requirements-root.txt
+++ b/web/requirements-root.txt
@@ -1,5 +1,3 @@
-datapunt-authorization-django
-datapunt-authorization-levels
 Django
 django-braces
 django-extensions

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -5,8 +5,6 @@ chardet==3.0.4
 coreapi==2.3.3
 coreschema==0.0.4
 cryptography==2.6.1
-datapunt-authorization-django==0.2.24
-datapunt-authorization-levels==0.1.3
 defusedxml==0.5.0
 Django==2.1.11
 django-braces==1.13.0

--- a/web/src/parkeervakken_api/settings.py
+++ b/web/src/parkeervakken_api/settings.py
@@ -55,27 +55,3 @@ DATABASES = {
 
 HEALTH_MODEL = 'parkeervakken_api.Parkeervak'
 
-# The following JWKS data was obtained in the authz project :  jwkgen -create -alg ES256   # noqa
-# This is a test public/private key def and added for testing .
-JWKS_TEST_KEY = """
-    {
-        "keys": [
-            {
-                "kty": "EC",
-                "key_ops": [
-                    "verify",
-                    "sign"
-                ],
-                "kid": "2aedafba-8170-4064-b704-ce92b7c89cc6",
-                "crv": "P-256",
-                "x": "6r8PYwqfZbq_QzoMA4tzJJsYUIIXdeyPA27qTgEJCDw=",
-                "y": "Cf2clfAfFuuCB06NMfIat9ultkMyrMQO9Hd2H7O9ZVE=",
-                "d": "N1vu0UQUp0vLfaNeM0EDbl4quvvL6m_ltjoAXXzkI3U="
-            }
-        ]
-    }
-"""
-
-DATAPUNT_AUTHZ = {
-    'JWKS': os.getenv('PUB_JWKS', JWKS_TEST_KEY)
-}

--- a/web/src/parkeervakken_api/settings_common.py
+++ b/web/src/parkeervakken_api/settings_common.py
@@ -57,7 +57,6 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'authorization_django.authorization_middleware',
 ]
 
 TEMPLATES = [


### PR DESCRIPTION
Seems like this api does not actually use the authorization middleware, so I think it's better to remove it.